### PR TITLE
Add logging to MultipartFileValidator

### DIFF
--- a/src/main/java/org/fontory/fontorybe/common/controller/GlobalExceptionHandler.java
+++ b/src/main/java/org/fontory/fontorybe/common/controller/GlobalExceptionHandler.java
@@ -8,6 +8,8 @@ import org.fontory.fontorybe.bookmark.domain.exception.BookmarkAlreadyException;
 import org.fontory.fontorybe.bookmark.domain.exception.BookmarkNotFoundException;
 import org.fontory.fontorybe.common.domain.BaseErrorResponse;
 import org.fontory.fontorybe.file.adapter.inbound.exception.FileUploadException;
+import org.fontory.fontorybe.file.domain.exception.InvalidMultipartRequestException;
+import org.fontory.fontorybe.file.domain.exception.SingleFileRequiredException;
 import org.fontory.fontorybe.font.domain.exception.FontNotFoundException;
 import org.fontory.fontorybe.font.domain.exception.FontOwnerMismatchException;
 import org.fontory.fontorybe.font.domain.exception.FontSQSProduceExcepetion;
@@ -112,6 +114,18 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
     @ExceptionHandler(FontSQSProduceExcepetion.class)
     public BaseErrorResponse SQSProduceException(FontSQSProduceExcepetion e) {
+        return new BaseErrorResponse(e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(SingleFileRequiredException.class)
+    public BaseErrorResponse singleFileRequiredException(SingleFileRequiredException e) {
+        return new BaseErrorResponse(e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(InvalidMultipartRequestException.class)
+    public BaseErrorResponse invalidMultipartRequest(InvalidMultipartRequestException e) {
         return new BaseErrorResponse(e.getMessage());
     }
 }

--- a/src/main/java/org/fontory/fontorybe/file/adapter/inbound/S3UploadController.java
+++ b/src/main/java/org/fontory/fontorybe/file/adapter/inbound/S3UploadController.java
@@ -1,5 +1,6 @@
 package org.fontory.fontorybe.file.adapter.inbound;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.fontory.fontorybe.authentication.adapter.inbound.Login;
 import org.fontory.fontorybe.authentication.adapter.inbound.OAuth2;
 import org.fontory.fontorybe.authentication.domain.UserPrincipal;
@@ -18,6 +19,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import static org.fontory.fontorybe.file.validator.MultipartFileValidator.*;
 
 @Slf4j
 @RestController
@@ -43,8 +46,11 @@ public class S3UploadController {
     @PostMapping("/profile-image")
     public ResponseEntity<?> uploadMemberProfileImage(
             @OAuth2 Provide provide,
-            @RequestPart MultipartFile file
+            HttpServletRequest request
+//            @RequestPart MultipartFile file
     ) {
+        MultipartFile file = extractSingleMultipartFile(request);
+
         log.info("Request received: Upload new profile image for oauth provider: {}, provideId: {}", 
                 provide.getProvider(), provide.getId());
         logFileDetails(file, "New profile image upload");
@@ -62,9 +68,12 @@ public class S3UploadController {
     @PutMapping("/profile-image")
     public ResponseEntity<?> uploadMemberProfileImage(
             @Login UserPrincipal userPrincipal,
-            @RequestPart MultipartFile file
+            HttpServletRequest request
+//            @RequestPart MultipartFile file
     ) {
         Long memberId = userPrincipal.getId();
+        MultipartFile file = extractSingleMultipartFile(request);
+
         log.info("Request received: Update profile image for member ID: {}", memberId);
         logFileDetails(file, "Profile image update");
         

--- a/src/main/java/org/fontory/fontorybe/file/domain/exception/InvalidMultipartRequestException.java
+++ b/src/main/java/org/fontory/fontorybe/file/domain/exception/InvalidMultipartRequestException.java
@@ -1,0 +1,7 @@
+package org.fontory.fontorybe.file.domain.exception;
+
+public class InvalidMultipartRequestException extends RuntimeException {
+    public InvalidMultipartRequestException() {
+        super("The request is not in multipart format.");
+    }
+}

--- a/src/main/java/org/fontory/fontorybe/file/domain/exception/SingleFileRequiredException.java
+++ b/src/main/java/org/fontory/fontorybe/file/domain/exception/SingleFileRequiredException.java
@@ -1,0 +1,7 @@
+package org.fontory.fontorybe.file.domain.exception;
+
+public class SingleFileRequiredException extends RuntimeException {
+    public SingleFileRequiredException() {
+        super("Exactly one file must be uploaded.");
+    }
+}

--- a/src/main/java/org/fontory/fontorybe/file/validator/MultipartFileValidator.java
+++ b/src/main/java/org/fontory/fontorybe/file/validator/MultipartFileValidator.java
@@ -1,0 +1,37 @@
+package org.fontory.fontorybe.file.validator;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.fontory.fontorybe.file.domain.exception.SingleFileRequiredException;
+import org.fontory.fontorybe.file.domain.exception.InvalidMultipartRequestException;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
+
+import java.util.List;
+
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MultipartFileValidator {
+    public static MultipartFile extractSingleMultipartFile(HttpServletRequest request) {
+        if (!(request instanceof MultipartHttpServletRequest multipartRequest)) {
+            log.error("Invalid request: Not a multipart request.");
+            throw new InvalidMultipartRequestException();
+        }
+
+        log.debug("Multipart request received.");
+        List<MultipartFile> files = multipartRequest.getFiles("file");
+        log.info("Number of files received: {}", files.size());
+
+        if (files.size() != 1) {
+            log.error("Invalid file count: {}. Exactly one file must be uploaded.", files.size());
+            throw new SingleFileRequiredException();
+        }
+
+        MultipartFile file = files.get(0);
+        log.info("Single file extracted successfully: filename={}, size={} bytes",
+                file.getOriginalFilename(), file.getSize());
+        return file;
+    }
+}


### PR DESCRIPTION
- Integrated SLF4J logging into MultipartFileValidator to track each validation step.
- Log an error and throw InvalidMultipartRequestException when the request is not a multipart request.
- Validate that exactly one file is uploaded by logging the file count.
- Log an error and throw SingleFileRequiredException if the file count is not one.
- Log successful extraction of the single file (including file name and size) at the info level.
- This enhancement improves debugging and operational issue tracing.