### PR TITLE
이벤트 기반 sms 알림 로직 도입 및 통합 테스트 추가

### DIFF
--- a/src/main/java/org/fontory/fontorybe/font/CoolSmsEventListener.java
+++ b/src/main/java/org/fontory/fontorybe/font/CoolSmsEventListener.java
@@ -1,0 +1,48 @@
+package org.fontory.fontorybe.font;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.fontory.fontorybe.font.domain.Font;
+import org.fontory.fontorybe.sms.application.port.PhoneNumberStorage;
+import org.fontory.fontorybe.sms.application.port.SmsService;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CoolSmsEventListener {
+
+    private final PhoneNumberStorage phoneNumberStorage;
+    private final SmsService smsService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void sendFontCreateRequestNotificationAndSavePhoneNumber(FontCreateRequestNotificationEvent e) {
+        Font font = e.getFont();
+        String phoneNumber = e.getPhoneNumber();
+
+        log.info("sms send start & save phone number in redis - fontId={}, phoneNumber={}", font.getId(), phoneNumber);
+
+        phoneNumberStorage.savePhoneNumber(font, phoneNumber);
+        smsService.sendFontCreateRequestNotification(phoneNumber, font.getName());
+
+        log.info("sms sent & phone number saved in redis - fontId={}, phoneNumber={}", font.getId(), phoneNumber);
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void sendFontCreateCompleteNotificationAndRemovePhoneNumber(FontCreateCompleteNotificationEvent e) {
+        Font font = e.getFont();
+        String phoneNumber = phoneNumberStorage.getPhoneNumber(font);
+
+        log.info("sms send start & save phone number in redis - fontId={}, phoneNumber={}", font.getId(), phoneNumber);
+
+        smsService.sendFontCreateCompleteNotification(phoneNumber, font.getName());
+        phoneNumberStorage.removePhoneNumber(font);
+
+        log.info("sms sent & phone number saved in redis - fontId={}, phoneNumber={}", font.getId(), phoneNumber);
+    }
+}

--- a/src/main/java/org/fontory/fontorybe/font/FontCreateCompleteNotificationEvent.java
+++ b/src/main/java/org/fontory/fontorybe/font/FontCreateCompleteNotificationEvent.java
@@ -1,0 +1,11 @@
+package org.fontory.fontorybe.font;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.fontory.fontorybe.font.domain.Font;
+
+@Getter
+@RequiredArgsConstructor
+public class FontCreateCompleteNotificationEvent {
+    private final Font font;
+}

--- a/src/main/java/org/fontory/fontorybe/font/FontCreateRequestNotificationEvent.java
+++ b/src/main/java/org/fontory/fontorybe/font/FontCreateRequestNotificationEvent.java
@@ -1,0 +1,12 @@
+package org.fontory.fontorybe.font;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.fontory.fontorybe.font.domain.Font;
+
+@Getter
+@RequiredArgsConstructor
+public class FontCreateRequestNotificationEvent {
+    private final Font font;
+    private final String phoneNumber;
+}

--- a/src/main/java/org/fontory/fontorybe/sms/application/SmsServiceImpl.java
+++ b/src/main/java/org/fontory/fontorybe/sms/application/SmsServiceImpl.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Service;
 public class SmsServiceImpl implements SmsService {
 
     @Value("${coolsms.phone-number}")
-    private String phoneNumber;
+    private String fromPhoneNumber;
 
     private final DefaultMessageService messageService;
 
@@ -23,25 +23,25 @@ public class SmsServiceImpl implements SmsService {
     private static final String FONT_PROGRESS_MESSAGE_FORMAT = "[Fontory]\n\"%s\" 폰트 제작이 완료되었습니다.";
 
     @Override
-    public void sendFontCreationNotification(String to, String fontName) {
+    public void sendFontCreateRequestNotification(String to, String fontName) {
         sendSms(to, String.format(FONT_CREATION_MESSAGE_FORMAT, fontName));
     }
 
     @Override
-    public void sendFontProgressNotification(String to, String fontName) {
+    public void sendFontCreateCompleteNotification(String to, String fontName) {
         sendSms(to, String.format(FONT_PROGRESS_MESSAGE_FORMAT, fontName));
     }
 
-    private void sendSms(String to, String text) {
-        if (to == null || to.isBlank()) {
+    private void sendSms(String toPhoneNumber, String content) {
+        if (toPhoneNumber == null || toPhoneNumber.isBlank()) {
             log.warn("Service warning: recipient phone number is empty");
             return;
         }
 
         Message message = new Message();
-        message.setFrom(phoneNumber);
-        message.setTo(to);
-        message.setText(text);
+        message.setFrom(fromPhoneNumber);
+        message.setTo(toPhoneNumber);
+        message.setText(content);
 
         messageService.sendOne(new SingleMessageSendingRequest(message));
     }

--- a/src/main/java/org/fontory/fontorybe/sms/application/port/SmsService.java
+++ b/src/main/java/org/fontory/fontorybe/sms/application/port/SmsService.java
@@ -1,6 +1,6 @@
 package org.fontory.fontorybe.sms.application.port;
 
 public interface SmsService {
-    void sendFontCreationNotification(String to, String fontName);
-    void sendFontProgressNotification(String to, String fontName);
+    void sendFontCreateRequestNotification(String to, String fontName);
+    void sendFontCreateCompleteNotification(String to, String fontName);
 }

--- a/src/test/java/org/fontory/fontorybe/integration/font/FontControllerIntegrationTest.java
+++ b/src/test/java/org/fontory/fontorybe/integration/font/FontControllerIntegrationTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -66,6 +67,8 @@ class FontControllerIntegrationTest {
     private FileService fileService;
     @MockitoBean
     private FontRequestProducer fontRequestProducer;
+    @MockitoBean
+    private ApplicationEventPublisher eventPublisher;
 
     private final Long existMemberId = 999L;
     private final String existMemberName = "existMemberNickName";

--- a/src/test/java/org/fontory/fontorybe/integration/font/FontServiceIntegrationTest.java
+++ b/src/test/java/org/fontory/fontorybe/integration/font/FontServiceIntegrationTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.jdbc.Sql;
@@ -43,6 +45,8 @@ class FontServiceIntegrationTest {
     private FileService fileService;
     @MockitoBean
     private FontRequestProducer fontRequestProducer;
+    @MockitoBean
+    private ApplicationEventPublisher eventPublisher;
 
     private final Long existMemberId = 999L;
     private final String existMemberName = "existMemberNickName";


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

- FontServiceImpl 내 폰트 생성 및 완료 시점에 이벤트 발행 로직 추가
  - FontCreateRequestNotificationEvent
  - FontCreateCompleteNotificationEvent
- SmsService 인터페이스 및 구현체에 관련 메서드 추가
- 통합 테스트(FontServiceIntegrationTest, FontControllerIntegrationTest)에서 이벤트 및 알림 로직 검증 추가

비동기 이벤트 기반으로 알림 로직을 분리하여 서비스 응답 속도 개선 및 관심사 분리 달성
