### PR TITLE
chore: Improve S3 Event Listener and Discord Notification Error Handling

### DIFF
--- a/src/main/java/org/fontory/fontorybe/common/adapter/outbound/DiscordExceptionLoggingAspect.java
+++ b/src/main/java/org/fontory/fontorybe/common/adapter/outbound/DiscordExceptionLoggingAspect.java
@@ -156,24 +156,28 @@ public class DiscordExceptionLoggingAspect {
      */
     @Async
     protected void sendToDiscord(String payloadJson, String fullStackTrace) {
-        byte[] stackTraceBytes = fullStackTrace.getBytes(StandardCharsets.UTF_8);
-        ByteArrayResource stackTraceResource = new ByteArrayResource(stackTraceBytes) {
-            @Override
-            public String getFilename() {
-                return "stacktrace.txt";
-            }
-        };
+        try {
+            byte[] stackTraceBytes = fullStackTrace.getBytes(StandardCharsets.UTF_8);
+            ByteArrayResource stackTraceResource = new ByteArrayResource(stackTraceBytes) {
+                @Override
+                public String getFilename() {
+                    return "stacktrace.txt";
+                }
+            };
 
-        LinkedMultiValueMap<String, Object> multipartBody = new LinkedMultiValueMap<>();
-        multipartBody.add("payload_json", payloadJson);
-        multipartBody.add("file", stackTraceResource);
+            LinkedMultiValueMap<String, Object> multipartBody = new LinkedMultiValueMap<>();
+            multipartBody.add("payload_json", payloadJson);
+            multipartBody.add("file", stackTraceResource);
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.MULTIPART_FORM_DATA);
 
-        HttpEntity<MultiValueMap<String, Object>> requestEntity =
-                new HttpEntity<>(multipartBody, headers);
+            HttpEntity<MultiValueMap<String, Object>> requestEntity =
+                    new HttpEntity<>(multipartBody, headers);
 
-        restTemplate.postForEntity(discordWebhookUrl, requestEntity, String.class);
+            restTemplate.postForEntity(discordWebhookUrl, requestEntity, String.class);
+        } catch (Exception e) {
+            log.warn("Exception occured while sending stacktrace to Discord: {}", e);
+        }
     }
 }

--- a/src/main/java/org/fontory/fontorybe/file/adapter/outbound/s3/ProfileImageUpdateListener.java
+++ b/src/main/java/org/fontory/fontorybe/file/adapter/outbound/s3/ProfileImageUpdateListener.java
@@ -28,8 +28,8 @@ public class ProfileImageUpdateListener {
         profileImagePrefix = s3Config.getPrefix(FileType.PROFILE_IMAGE);
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
-    public void beforeCommit(ProfileImageUpdatedEvent event) {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void afterCommit(ProfileImageUpdatedEvent event) {
         s3.copyObject(CopyObjectRequest.builder()
                         .sourceBucket(profileImageBucketName)
                         .sourceKey(profileImagePrefix + "/" + event.getTempKey())

--- a/src/main/java/org/fontory/fontorybe/file/adapter/outbound/s3/ProfileImageUpdateListener.java
+++ b/src/main/java/org/fontory/fontorybe/file/adapter/outbound/s3/ProfileImageUpdateListener.java
@@ -30,17 +30,23 @@ public class ProfileImageUpdateListener {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void afterCommit(ProfileImageUpdatedEvent event) {
-        s3.copyObject(CopyObjectRequest.builder()
-                        .sourceBucket(profileImageBucketName)
-                        .sourceKey(profileImagePrefix + "/" + event.getTempKey())
-                        .destinationBucket(profileImageBucketName)
-                        .destinationKey(profileImagePrefix + "/" + event.getFixedKey())
-                        .build());
+        try {
+            s3.copyObject(CopyObjectRequest.builder()
+                            .sourceBucket(profileImageBucketName)
+                            .sourceKey(profileImagePrefix + "/" + event.getTempKey())
+                            .destinationBucket(profileImageBucketName)
+                            .destinationKey(profileImagePrefix + "/" + event.getFixedKey())
+                            .build());
 
-        s3.deleteObject(DeleteObjectRequest.builder()
-                .bucket(profileImageBucketName)
-                .key(profileImagePrefix + "/" + event.getTempKey())
-                .build());
+            s3.deleteObject(DeleteObjectRequest.builder()
+                    .bucket(profileImageBucketName)
+                    .key(profileImagePrefix + "/" + event.getTempKey())
+                    .build());
+        } catch (Exception e) {
+            log.error("Error while copying/deleting profile image to s3: tempKey={}, fixedKey={}",
+                    event.getTempKey(), event.getFixedKey(), e);
+            throw e;
+        }
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)


### PR DESCRIPTION
### 변경 사항
- **리스너 Phase 변경**  
  `@TransactionalEventListener` 실행 시점을 `BEFORE_COMMIT` → `AFTER_COMMIT`으로 수정하여 DB 커밋 후 S3 작업 실행
- **afterCommit 예외 처리 추가**  
  S3 `copyObject`/`deleteObject` 호출을 `try–catch`로 감싸고, 에러 발생 시 로그 출력 후 예외 재던지기
- **sendToDiscord 예외 처리 추가**  
  `@Async`로 실행되는 Discord 웹훅 전송을 `try–catch`로 감싸고, 전송 실패 시 경고 로그만 남기도록 수정